### PR TITLE
NICMOS pipeline & shm spt mast download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,6 @@ dmypy.json
 # MacOS
 .DS_Store
 >>>>>>> pdart3-repo/master
+
+# Output from make
+tmp*.xml

--- a/CheckSubarrayFlag.py
+++ b/CheckSubarrayFlag.py
@@ -10,13 +10,13 @@ from pdart.db.BundleDB import (
 from pdart.db.SqlAlchTables import Card, switch_on_collection_subtype
 from pdart.pds4.LIDVID import LIDVID
 
-TWD = "/Volumes/Eric's-5TB/tmp-working-dir"
+TWD = os.environ["TMP_WORKING_DIR"]
 
 
 def has_subarray(db: BundleDB) -> bool:
-    subarray_cards: List[Card] = db.session.query(Card).filter(
-        Card.keyword == "SUBARRAY"
-    ).all()
+    subarray_cards: List[Card] = (
+        db.session.query(Card).filter(Card.keyword == "SUBARRAY").all()
+    )
     return len(subarray_cards) != 0
 
 

--- a/Download_SHM_SPT.py
+++ b/Download_SHM_SPT.py
@@ -16,6 +16,4 @@ if __name__ == "__main__":
     working_dir = dirs.working_dir(proposal_id)
     slice = MastSlice((1900, 1, 1), (2025, 1, 1), proposal_id)
     product_set = slice.to_product_set(proposal_id, True)
-    # if not os.path.isdir(working_dir):
-    #     os.makedirs(working_dir)
     product_set.download(working_dir)

--- a/Download_SHM_SPT.py
+++ b/Download_SHM_SPT.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from pdart.astroquery.AcceptedSuffixes import (
+    ACCEPTED_SUFFIXES,
+    PART_OF_ACCEPTED_SUFFIXES,
+)
+from pdart.astroquery.Astroquery import MastSlice, ProductSet
+from pdart.pipeline.Directories import DevDirectories
+
+# Download from Mast
+if __name__ == "__main__":
+    TWD = os.environ["TMP_WORKING_DIR"]
+    assert len(sys.argv) == 2, sys.argv
+    proposal_id = int(sys.argv[1])
+    dirs = DevDirectories(TWD + "/shm_spt_from_mast")
+    working_dir = dirs.working_dir(proposal_id)
+    slice = MastSlice((1900, 1, 1), (2025, 1, 1), proposal_id)
+    product_set = slice.to_product_set(proposal_id, True)
+    # if not os.path.isdir(working_dir):
+    #     os.makedirs(working_dir)
+    product_set.download(working_dir)

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,14 @@ lil-pipeline : venv
 	say lil pipeline is done
 	open $(LIL-TWD)
 
+##############################
+# Pipeline for NICMOS ONLY
+##############################
+LILS=07885
+
+.PHONY: nicmos-pipeline
+nicmos-pipeline : lil-pipeline
+
 
 ############################################################
 # CHECK SUBARRAY FLAG

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ PIP=python3 -m pip
 
 # Format, typecheck, and test.
 .PHONY: all
-# all : phome
 all : black mypy test
 
 ############################################################
@@ -27,12 +26,11 @@ MYPY_FLAGS=--disallow-any-unimported \
 # --warn-return-any: not practical because of SqlAlchemy's dynamic magic
 # and because FITS cards are untyped.
 
-.PHONY: phome
-phome:
+.PHONY: print-var
+print-var:
 	@echo $(HOME)
-	@echo $(TMP_WORKING_DIR)/zips
+	@echo $(TMP_WORKING_DIR)
 	@echo $(PDSTOOLS_PATH)
-	@echo $(PATH)
 
 .PHONY: mypy
 mypy : venv

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ nicmos-pipeline : setup_dir
 ##############################
 # Download shm & spt from mast
 ##############################
-TEST_ID:=07885 09059
+TEST_ID=07885 09059
 
 .PHONY: download-shm-spt
 download-shm-spt : setup_dir

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ lil-pipeline : venv
 	-rm $(LIL-TWD)/*/\#*.txt
 	for project_id in $(LILS); do \
 	    echo '****' hst_$$project_id '****'; \
-	    $(ACTIVATE) && LIL=True PYTHONPATH=$(PDSTOOLS_PATH) \
+	    $(ACTIVATE) && PYTHONPATH=$(PDSTOOLS_PATH) \
 		python Pipeline.py $$project_id; \
 	done;
 	say lil pipeline is done
@@ -141,7 +141,7 @@ NICMOS_ID=07885
 nicmos-pipeline : setup_dir
 	for project_id in $(NICMOS_ID); do \
 	    echo '****' hst_$$project_id '****'; \
-	    $(ACTIVATE) && LIL=True PYTHONPATH=$(PDSTOOLS_PATH) \
+	    $(ACTIVATE) && PYTHONPATH=$(PDSTOOLS_PATH) \
 		python Pipeline.py $$project_id; \
 	done;
 	say lil pipeline is done
@@ -150,7 +150,7 @@ nicmos-pipeline : setup_dir
 ##############################
 # Download shm & spt from mast
 ##############################
-TEST_ID=09748 15505
+TEST_ID=07885 09059 09748 15505
 
 .PHONY: download-shm-spt
 download-shm-spt : setup_dir

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ copy-results :
 # smaller version for testing
 ##############################
 
-LILS=09059 09748 15505
+LILS=07885 09059 09748 15505
 
 .PHONY: lil-pipeline
 LIL-TWD=$(TMP_WORKING_DIR)
@@ -150,26 +150,13 @@ nicmos-pipeline : setup_dir
 	open $(LIL-TWD)
 
 ##############################
-# Pipeline for shm & spt ONLY
-##############################
-SHM_SPT_PIPELINE_ID:=09059
-
-.PHONY: shm-spt-pipeline
-shm-spt-pipeline : setup_dir
-	for project_id in $(SHM_SPT_PIPELINE_ID); do \
-	    echo '****' hst_$$project_id '****'; \
-	    $(ACTIVATE) && PYTHONPATH=$(PDSTOOLS_PATH) \
-		python Pipeline.py $$project_id -c; \
-	done;
-
-##############################
 # Download shm & spt from mast
 ##############################
 TEST_ID:=07885 09059
 
 .PHONY: download-shm-spt
 download-shm-spt : setup_dir
-	for project_id in $(TEST_ID); do \
+	for project_id in $(PROJ_IDS); do \
 		echo '****' hst_$$project_id '****'; \
 		$(ACTIVATE) && PYTHONPATH=$(PDSTOOLS_PATH) \
 		python Download_SHM_SPT.py $$project_id; \

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ nicmos-pipeline : setup_dir
 ##############################
 # Download shm & spt from mast
 ##############################
-TEST_ID=07885 09059
+TEST_ID=09748 15505
 
 .PHONY: download-shm-spt
 download-shm-spt : setup_dir

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,20 @@ LILS=07885
 .PHONY: nicmos-pipeline
 nicmos-pipeline : lil-pipeline
 
+##############################
+# Download shm & spt from mast
+##############################
+LILS=07885 09059
+
+.PHONY: download-shm-spt
+download-shm-spt : venv
+	mkdir -p $(LIL-TWD)
+	for project_id in $(LILS); do \
+		echo '****' hst_$$project_id '****'; \
+		$(ACTIVATE) && PYTHONPATH=$(PDSTOOLS_PATH) \
+		python Download_SHM_SPT.py $$project_id; \
+	done;
+
 
 ############################################################
 # CHECK SUBARRAY FLAG

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ PIP=python3 -m pip
 
 # Format, typecheck, and test.
 .PHONY: all
+# all : phome
 all : black mypy test
 
 ############################################################
@@ -26,12 +27,19 @@ MYPY_FLAGS=--disallow-any-unimported \
 # --warn-return-any: not practical because of SqlAlchemy's dynamic magic
 # and because FITS cards are untyped.
 
+.PHONY: phome
+phome:
+	@echo $(HOME)
+	@echo $(TMP_WORKING_DIR)/zips
+	@echo $(PDSTOOLS_PATH)
+	@echo $(PATH)
+
 .PHONY: mypy
 mypy : venv
 	$(ACTIVATE) && MYPYPATH=stubs mypy $(MYPY_FLAGS) *.py pdart
 
 experiment : venv black mypy
-	$(ACTIVATE) && PYTHONPATH=$(HOME)/pds-tools python3 Experiment.py
+	$(ACTIVATE) && PYTHONPATH=$(PDSTOOLS_PATH) python3 Experiment.py
 
 
 ############################################################
@@ -41,20 +49,20 @@ experiment : venv black mypy
 # Run the tests.
 .PHONY: test
 test: venv
-	$(ACTIVATE) && PYTHONPATH=$(HOME)/pds-tools pytest pdart
+	$(ACTIVATE) && PYTHONPATH=$(PDSTOOLS_PATH) pytest pdart
 
 # Run some subset of the tests.  Hack as needed.
 .PHONY: t
 t: venv
-	$(ACTIVATE) && PYTHONPATH=$(HOME)/pds-tools pytest pdart/labels/test_HstParameters.py
+	$(ACTIVATE) && PYTHONPATH=$(PDSTOOLS_PATH) pytest pdart/labels/test_HstParameters.py
 
 
 ############################################################
 # THE PIPELINE
 ############################################################
 
-TWD="/Volumes/Eric's-5TB/tmp-working-dir"
-ZIPS="/Volumes/Eric's-5TB/zips"
+TWD=$(TMP_WORKING_DIR)
+ZIPS=$(TMP_WORKING_DIR)/zips
 
 ACS_IDS=09059 09296 09440 09678 09725 09745 09746 09985 10192 10461	\
 10502 10506 10508 10545 10719 10774 10783 11055 11109 12601 13012	\
@@ -82,7 +90,7 @@ pipeline : venv clean-results
 	-rm $(TWD)/hst_*/\#*.txt
 	for project_id in $(PROJ_IDS); do \
 	    echo '****' hst_$$project_id '****'; \
-	    $(ACTIVATE) && PYTHONPATH=$(HOME)/pds-tools \
+	    $(ACTIVATE) && PYTHONPATH=$(PDSTOOLS_PATH) \
 		python Pipeline.py $$project_id; \
 	done;
 	say pipeline is done
@@ -114,13 +122,13 @@ copy-results :
 LILS=09059 09748 15505
 
 .PHONY: lil-pipeline
-LIL-TWD=tmp-working-dir
+LIL-TWD=$(TMP_WORKING_DIR)
 lil-pipeline : venv
 	mkdir -p $(LIL-TWD)
 	-rm $(LIL-TWD)/*/\#*.txt
 	for project_id in $(LILS); do \
 	    echo '****' hst_$$project_id '****'; \
-	    $(ACTIVATE) && LIL=True PYTHONPATH=$(HOME)/pds-tools \
+	    $(ACTIVATE) && LIL=True PYTHONPATH=$(PDSTOOLS_PATH) \
 		python Pipeline.py $$project_id; \
 	done;
 	say lil pipeline is done
@@ -184,4 +192,4 @@ clean : tidy
 
 .PHONY: target_files
 target_files : venv
-	$(ACTIVATE) && PYTHONPATH=$(HOME)/pds-tools python3 DownloadTargetFiles.py
+	$(ACTIVATE) && PYTHONPATH=$(PDSTOOLS_PATH) python3 DownloadTargetFiles.py

--- a/Makefile
+++ b/Makefile
@@ -137,25 +137,50 @@ lil-pipeline : venv
 ##############################
 # Pipeline for NICMOS ONLY
 ##############################
-LILS=07885
+NICMOS_ID=07885
 
 .PHONY: nicmos-pipeline
-nicmos-pipeline : lil-pipeline
+nicmos-pipeline : setup_dir
+	for project_id in $(NICMOS_ID); do \
+	    echo '****' hst_$$project_id '****'; \
+	    $(ACTIVATE) && LIL=True PYTHONPATH=$(PDSTOOLS_PATH) \
+		python Pipeline.py $$project_id; \
+	done;
+	say lil pipeline is done
+	open $(LIL-TWD)
+
+##############################
+# Pipeline for shm & spt ONLY
+##############################
+SHM_SPT_PIPELINE_ID:=09059
+
+.PHONY: shm-spt-pipeline
+shm-spt-pipeline : setup_dir
+	for project_id in $(SHM_SPT_PIPELINE_ID); do \
+	    echo '****' hst_$$project_id '****'; \
+	    $(ACTIVATE) && PYTHONPATH=$(PDSTOOLS_PATH) \
+		python Pipeline.py $$project_id -c; \
+	done;
 
 ##############################
 # Download shm & spt from mast
 ##############################
-LILS=07885 09059
+TEST_ID:=07885 09059
 
 .PHONY: download-shm-spt
-download-shm-spt : venv
-	mkdir -p $(LIL-TWD)
-	for project_id in $(LILS); do \
+download-shm-spt : setup_dir
+	for project_id in $(TEST_ID); do \
 		echo '****' hst_$$project_id '****'; \
 		$(ACTIVATE) && PYTHONPATH=$(PDSTOOLS_PATH) \
 		python Download_SHM_SPT.py $$project_id; \
 	done;
 
+############################################################
+# Setup
+############################################################
+setup_dir : venv
+	mkdir -p $(LIL-TWD)
+	-rm $(LIL-TWD)/*/\#*.txt
 
 ############################################################
 # CHECK SUBARRAY FLAG

--- a/Pipeline.py
+++ b/Pipeline.py
@@ -4,14 +4,10 @@ from pdart.pipeline.StateMachine import StateMachine
 
 
 def run() -> None:
-    assert len(sys.argv) <= 3, sys.argv
+    assert len(sys.argv) == 2, sys.argv
     proposal_id = int(sys.argv[1])
-    selected_suffixes = False
-    if len(sys.argv) == 3:
-        use_selected_suffixes = sys.argv[2]
-        selected_suffixes = True if use_selected_suffixes == "-c" else False
     dirs = make_directories()
-    state_machine = StateMachine(dirs, proposal_id, selected_suffixes)
+    state_machine = StateMachine(dirs, proposal_id)
     state_machine.run()
 
 

--- a/Pipeline.py
+++ b/Pipeline.py
@@ -4,10 +4,12 @@ from pdart.pipeline.StateMachine import StateMachine
 
 
 def run() -> None:
-    assert len(sys.argv) == 2, sys.argv
+    assert len(sys.argv) <= 3, sys.argv
     proposal_id = int(sys.argv[1])
+    use_selected_suffixes = sys.argv[2]
+    selected_suffixes = True if use_selected_suffixes == "-c" else False
     dirs = make_directories()
-    state_machine = StateMachine(dirs, proposal_id)
+    state_machine = StateMachine(dirs, proposal_id, selected_suffixes)
     state_machine.run()
 
 

--- a/Pipeline.py
+++ b/Pipeline.py
@@ -6,8 +6,10 @@ from pdart.pipeline.StateMachine import StateMachine
 def run() -> None:
     assert len(sys.argv) <= 3, sys.argv
     proposal_id = int(sys.argv[1])
-    use_selected_suffixes = sys.argv[2]
-    selected_suffixes = True if use_selected_suffixes == "-c" else False
+    selected_suffixes = False
+    if len(sys.argv) == 3:
+        use_selected_suffixes = sys.argv[2]
+        selected_suffixes = True if use_selected_suffixes == "-c" else False
     dirs = make_directories()
     state_machine = StateMachine(dirs, proposal_id, selected_suffixes)
     state_machine.run()

--- a/context-products.json
+++ b/context-products.json
@@ -18,6 +18,11 @@
     {
       "name": [],
       "type": [],
+      "lidvid": "urn:nasa:pds:context:instrument:insthost.nicmos::1.0"
+    },
+    {
+      "name": [],
+      "type": [],
       "lidvid": "urn:nasa:pds:context:investigation:investigation.hst_05167::1.0"
     },
     {
@@ -494,6 +499,11 @@
       "name": [],
       "type": [],
       "lidvid": "urn:nasa:pds:context:investigation:investigation.hst_07717::1.0"
+    },
+    {
+      "name": [],
+      "type": [],
+      "lidvid": "urn:nasa:pds:context:investigation:investigation.hst_07885::1.0"
     },
     {
       "name": [],

--- a/pdart/astroquery/AcceptedSuffixes.py
+++ b/pdart/astroquery/AcceptedSuffixes.py
@@ -1,0 +1,46 @@
+from typing import List
+
+ACCEPTED_SUFFIXES: List[str] = [
+    "A1F",
+    "A2F",
+    "A3F",
+    "ASC",
+    "ASN",
+    # "C0F", # waivered
+    # "C1F", # waivered
+    # "C2F", # waivered
+    # "C3F", # waivered
+    "C0M",
+    "C1M",
+    "C2M",
+    "C3M",
+    "CAL",
+    "CLB",
+    "CLF",
+    "CORRTAG",
+    "CQF",
+    "CRC",
+    "CRJ",
+    # "D0F", # waivered
+    "D0M",
+    "DRC",
+    "DRZ",
+    "FLC",
+    "FLT",
+    "FLTSUM",
+    "MOS",
+    "RAW",
+    # "SHF", # waivered
+    "SHM",
+    "SPT",
+    "SX2",
+    "SXL",
+    "X1D",
+    "X1DSUM",
+    "X2D",
+]
+
+PART_OF_ACCEPTED_SUFFIXES: List[str] = [
+    "SHM",
+    "SPT",
+]

--- a/pdart/astroquery/Astroquery.py
+++ b/pdart/astroquery/Astroquery.py
@@ -108,9 +108,7 @@ class MastSlice(object):
             self.proposal_ids = sorted(list(set(result)))
         return self.proposal_ids
 
-    def get_products(
-        self, proposal_id: int, selected_suffixes: Optional[bool] = False
-    ) -> Table:
+    def get_products(self, proposal_id: int, selected_suffixes: bool = False) -> Table:
         def proposal_id_matches(row: Row) -> bool:
             return int(row["proposal_id"]) == proposal_id
 
@@ -127,7 +125,7 @@ class MastSlice(object):
         return result
 
     def to_product_set(
-        self, proposal_id: int, selected_suffixes: Optional[bool] = False
+        self, proposal_id: int, selected_suffixes: bool = False
     ) -> "ProductSet":
         return ProductSet(self.get_products(proposal_id, selected_suffixes))
 

--- a/pdart/astroquery/Astroquery.py
+++ b/pdart/astroquery/Astroquery.py
@@ -4,6 +4,11 @@ from astropy.table import Table
 from astropy.table.row import Row
 from astroquery.mast import Observations
 
+from pdart.astroquery.AcceptedSuffixes import (
+    ACCEPTED_SUFFIXES,
+    PART_OF_ACCEPTED_SUFFIXES,
+)
+
 from pdart.astroquery.Utils import (
     filter_table,
     get_table_with_retries,
@@ -19,46 +24,45 @@ _ACCEPTED_INSTRUMENTS: str = "IJNU"
 We currently only handle products from a limited set of
 instruments.  These are the first letters of their 'obs_id's.
 """
-# SHM, SPT
-ACCEPTED_SUFFIXES: List[str] = [
-    "A1F",
-    "A2F",
-    "A3F",
-    "ASC",
-    "ASN",
-    # "C0F", # waivered
-    # "C1F", # waivered
-    # "C2F", # waivered
-    # "C3F", # waivered
-    "C0M",
-    "C1M",
-    "C2M",
-    "C3M",
-    "CAL",
-    "CLB",
-    "CLF",
-    "CORRTAG",
-    "CQF",
-    "CRC",
-    "CRJ",
-    # "D0F", # waivered
-    "D0M",
-    "DRC",
-    "DRZ",
-    "FLC",
-    "FLT",
-    "FLTSUM",
-    "MOS",
-    "RAW",
-    # "SHF", # waivered
-    "SHM",
-    "SPT",
-    "SX2",
-    "SXL",
-    "X1D",
-    "X1DSUM",
-    "X2D",
-]
+# ACCEPTED_SUFFIXES: List[str] = [
+#     "A1F",
+#     "A2F",
+#     "A3F",
+#     "ASC",
+#     "ASN",
+#     # "C0F", # waivered
+#     # "C1F", # waivered
+#     # "C2F", # waivered
+#     # "C3F", # waivered
+#     "C0M",
+#     "C1M",
+#     "C2M",
+#     "C3M",
+#     "CAL",
+#     "CLB",
+#     "CLF",
+#     "CORRTAG",
+#     "CQF",
+#     "CRC",
+#     "CRJ",
+#     # "D0F", # waivered
+#     "D0M",
+#     "DRC",
+#     "DRZ",
+#     "FLC",
+#     "FLT",
+#     "FLTSUM",
+#     "MOS",
+#     "RAW",
+#     # "SHF", # waivered
+#     "SHM",
+#     "SPT",
+#     "SX2",
+#     "SXL",
+#     "X1D",
+#     "X1DSUM",
+#     "X2D",
+# ]
 """
 For now, we limit the types of the products to those with these
 suffixes.
@@ -88,6 +92,15 @@ def _is_accepted_product_type_product_row(row: Row) -> bool:
     """
     desc = str(row["productSubGroupDescription"])
     return desc.upper() in ACCEPTED_SUFFIXES
+
+
+def _is_selected_accepted_product_type_product_row(row: Row) -> bool:
+    """
+    We currently only handle products from a limited set of
+    instruments with selected suffixes.
+    """
+    desc = str(row["productSubGroupDescription"])
+    return desc.upper() in PART_OF_ACCEPTED_SUFFIXES
 
 
 class MastSlice(object):
@@ -140,7 +153,9 @@ class MastSlice(object):
             self.proposal_ids = sorted(list(set(result)))
         return self.proposal_ids
 
-    def get_products(self, proposal_id: int) -> Table:
+    def get_products(
+        self, proposal_id: int, selected_suffixes: Optional[bool] = False
+    ) -> Table:
         def proposal_id_matches(row: Row) -> bool:
             return int(row["proposal_id"]) == proposal_id
 
@@ -148,11 +163,18 @@ class MastSlice(object):
 
         result = Observations.get_product_list(proposal_table)
         result = filter_table(_is_accepted_instrument_product_row, result)
-        result = filter_table(_is_accepted_product_type_product_row, result)
+        if selected_suffixes:
+            result = filter_table(_is_accepted_product_type_product_row, result)
+        else:
+            result = filter_table(
+                _is_selected_accepted_product_type_product_row, result
+            )
         return result
 
-    def to_product_set(self, proposal_id: int) -> "ProductSet":
-        return ProductSet(self.get_products(proposal_id))
+    def to_product_set(
+        self, proposal_id: int, selected_suffixes: Optional[bool] = False
+    ) -> "ProductSet":
+        return ProductSet(self.get_products(proposal_id, selected_suffixes))
 
     def download_products(self, products_table: Table, download_dir: str) -> None:
         if len(products_table) > 0:

--- a/pdart/astroquery/Astroquery.py
+++ b/pdart/astroquery/Astroquery.py
@@ -12,8 +12,9 @@ from pdart.astroquery.Utils import (
 
 _YMD = Tuple[int, int, int]
 
-_ACCEPTED_INSTRUMENTS: str = "IJU"
-# _ACCEPTED_INSTRUMENTS: str = "IJUN"
+_ACCEPTED_INSTRUMENTS: str = "IJNU"
+# _ACCEPTED_INSTRUMENTS: str = "IJU"
+
 """
 We currently only handle products from a limited set of
 instruments.  These are the first letters of their 'obs_id's.

--- a/pdart/astroquery/Astroquery.py
+++ b/pdart/astroquery/Astroquery.py
@@ -164,11 +164,11 @@ class MastSlice(object):
         result = Observations.get_product_list(proposal_table)
         result = filter_table(_is_accepted_instrument_product_row, result)
         if selected_suffixes:
-            result = filter_table(_is_accepted_product_type_product_row, result)
-        else:
             result = filter_table(
                 _is_selected_accepted_product_type_product_row, result
             )
+        else:
+            result = filter_table(_is_accepted_product_type_product_row, result)
         return result
 
     def to_product_set(

--- a/pdart/astroquery/Astroquery.py
+++ b/pdart/astroquery/Astroquery.py
@@ -13,11 +13,12 @@ from pdart.astroquery.Utils import (
 _YMD = Tuple[int, int, int]
 
 _ACCEPTED_INSTRUMENTS: str = "IJU"
+# _ACCEPTED_INSTRUMENTS: str = "IJUN"
 """
 We currently only handle products from a limited set of
 instruments.  These are the first letters of their 'obs_id's.
 """
-
+# SHM, SPT
 ACCEPTED_SUFFIXES: List[str] = [
     "A1F",
     "A2F",

--- a/pdart/astroquery/Astroquery.py
+++ b/pdart/astroquery/Astroquery.py
@@ -18,54 +18,9 @@ from pdart.astroquery.Utils import (
 _YMD = Tuple[int, int, int]
 
 _ACCEPTED_INSTRUMENTS: str = "IJNU"
-# _ACCEPTED_INSTRUMENTS: str = "IJU"
-
 """
 We currently only handle products from a limited set of
 instruments.  These are the first letters of their 'obs_id's.
-"""
-# ACCEPTED_SUFFIXES: List[str] = [
-#     "A1F",
-#     "A2F",
-#     "A3F",
-#     "ASC",
-#     "ASN",
-#     # "C0F", # waivered
-#     # "C1F", # waivered
-#     # "C2F", # waivered
-#     # "C3F", # waivered
-#     "C0M",
-#     "C1M",
-#     "C2M",
-#     "C3M",
-#     "CAL",
-#     "CLB",
-#     "CLF",
-#     "CORRTAG",
-#     "CQF",
-#     "CRC",
-#     "CRJ",
-#     # "D0F", # waivered
-#     "D0M",
-#     "DRC",
-#     "DRZ",
-#     "FLC",
-#     "FLT",
-#     "FLTSUM",
-#     "MOS",
-#     "RAW",
-#     # "SHF", # waivered
-#     "SHM",
-#     "SPT",
-#     "SX2",
-#     "SXL",
-#     "X1D",
-#     "X1DSUM",
-#     "X2D",
-# ]
-"""
-For now, we limit the types of the products to those with these
-suffixes.
 """
 
 

--- a/pdart/citations/Citation_Information_from_pro.py
+++ b/pdart/citations/Citation_Information_from_pro.py
@@ -95,7 +95,9 @@ PROPNO_REGEX2 = re.compile(r" *HUBBLE SPACE TELESCOPE OBSERVING PROGRAM ([0-9]+)
 # Sometimes "2. Scientific Category" appears in front of the category and cycle
 # number, sometimes not
 INFO_HEADER1 = re.compile(r"2\. *Scientific Category +3\. *Proposal For +4\. *Cycle\s*")
-INFO_REGEX1 = re.compile(r".{22} *" + CATEGORIES + r"(?:|/[\w/]+) +([0-9]+)\s*",)
+INFO_REGEX1 = re.compile(
+    r".{22} *" + CATEGORIES + r"(?:|/[\w/]+) +([0-9]+)\s*",
+)
 INFO_HEADER2 = re.compile(r"2\.  *Proposal For +3\. *Cycle\s*")
 INFO_HEADER2a = re.compile(r"Type +Cycle +.*")
 INFO_REGEX2 = re.compile(r" *" + CATEGORIES + r"(?:|/[\w/]+) +([0-9]+)\s*")

--- a/pdart/fs/primitives/FSPrimAdapter.py
+++ b/pdart/fs/primitives/FSPrimAdapter.py
@@ -216,8 +216,7 @@ class FSPrimAdapter(FS):
 
     @classmethod
     def _make_details_from_stat(cls, stat_result: Any) -> Dict[str, Any]:
-        """Make a *details* info dict from an `os.stat_result` object.
-        """
+        """Make a *details* info dict from an `os.stat_result` object."""
         details: Dict[str, Any] = {
             "_write": ["accessed", "modified"],
             "accessed": stat_result.st_atime,
@@ -255,8 +254,7 @@ class FSPrimAdapter(FS):
 
     @classmethod
     def _get_type_from_stat(cls, _stat: Any) -> ResourceType:
-        """Get the resource type from an `os.stat_result` object.
-        """
+        """Get the resource type from an `os.stat_result` object."""
         st_mode = _stat.st_mode
         st_type = stat.S_IFMT(st_mode)
         return cls.STAT_TO_RESOURCE_TYPE.get(st_type, ResourceType.unknown)

--- a/pdart/labels/DocumentProductLabelXml.py
+++ b/pdart/labels/DocumentProductLabelXml.py
@@ -57,7 +57,7 @@ def _make_proposal_description(
 ) -> str:
     """
     Return a string the describes the proposal.
-     """
+    """
     return (
         "This document provides a summary of the observation "
         f"plan for HST proposal {proposal_id}, {proposal_title}, "

--- a/pdart/labels/FitsProductLabel.py
+++ b/pdart/labels/FitsProductLabel.py
@@ -24,6 +24,7 @@ from pdart.labels.FitsProductLabelXml import (
 from pdart.labels.HstParameters import (
     get_hst_parameters,
     get_start_stop_date_times,
+    get_exposure_duration,
 )
 from pdart.labels.LabelError import LabelError
 from pdart.labels.ObservingSystem import (
@@ -182,10 +183,11 @@ def make_fits_product_label(
         start_date_time, stop_date_time = get_start_stop_date_times(
             hdu_lookups, shm_lookup
         )
+        exposure_duration = get_exposure_duration(hdu_lookups, shm_lookup)
         start_stop_times = {
             "start_date_time": start_date_time,
             "stop_date_time": stop_date_time,
-            "exposure_duration": "0.1",  # TODO A totally bogus value
+            "exposure_duration": exposure_duration,  # TODO A totally bogus value
         }
 
         hst_parameters = get_hst_parameters(hdu_lookups, shm_lookup)

--- a/pdart/labels/FitsProductLabel.py
+++ b/pdart/labels/FitsProductLabel.py
@@ -187,7 +187,7 @@ def make_fits_product_label(
         start_stop_times = {
             "start_date_time": start_date_time,
             "stop_date_time": stop_date_time,
-            "exposure_duration": exposure_duration,  # TODO A totally bogus value
+            "exposure_duration": exposure_duration,
         }
 
         hst_parameters = get_hst_parameters(hdu_lookups, shm_lookup)

--- a/pdart/labels/Namespaces.py
+++ b/pdart/labels/Namespaces.py
@@ -2,17 +2,25 @@ from pdart.xml.Pds4Version import HST_SHORT_VERSION, PDS4_SHORT_VERSION
 
 _PDS4_SCHEMA_LOCATION: str = "http://pds.nasa.gov/pds4/pds/v1"
 
-_VERSIONED_PDS4_SCHEMA_LOCATION: str = f"https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_{PDS4_SHORT_VERSION}.xsd"
+_VERSIONED_PDS4_SCHEMA_LOCATION: str = (
+    f"https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_{PDS4_SHORT_VERSION}.xsd"
+)
 
-_VERSIONED_PDS4_SCHEMATRON_LOCATION: str = f"https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_{PDS4_SHORT_VERSION}.sch"
+_VERSIONED_PDS4_SCHEMATRON_LOCATION: str = (
+    f"https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_{PDS4_SHORT_VERSION}.sch"
+)
 
 
 _HST_SCHEMA_LOCATION: str = f"http://pds.nasa.gov/pds4/mission/hst/v1"
 
-_VERSIONED_HST_SCHEMA_LOCATION: str = f"https://pds.nasa.gov/pds4/mission/hst/v1/PDS4_HST_{HST_SHORT_VERSION}.xsd"
+_VERSIONED_HST_SCHEMA_LOCATION: str = (
+    f"https://pds.nasa.gov/pds4/mission/hst/v1/PDS4_HST_{HST_SHORT_VERSION}.xsd"
+)
 
 
-_VERSIONED_HST_SCHEMATRON_LOCATION: str = f"https://pds.nasa.gov/pds4/mission/hst/v1/PDS4_HST_{HST_SHORT_VERSION}.sch"
+_VERSIONED_HST_SCHEMATRON_LOCATION: str = (
+    f"https://pds.nasa.gov/pds4/mission/hst/v1/PDS4_HST_{HST_SHORT_VERSION}.sch"
+)
 
 
 ############################################################

--- a/pdart/labels/ObservingSystem.py
+++ b/pdart/labels/ObservingSystem.py
@@ -67,6 +67,15 @@ An interpreted fragment template to create an ``<Observing_System />``
 XML element.
 """
 
+nicmos_observing_system: NodeBuilder = _observing_system(
+    {
+        "name": "Hubble Space Telescope Near Infrared Camera and Multi-Object Spectrometer",
+        "component_name": "Near Infrared Camera and Multi-Object Spectrometer",
+        "instrument_lid": "urn:nasa:pds:context:instrument:insthost.nicmos",
+        "instrument_host_lid": "urn:nasa:pds:context:instrument_host:spacecraft.hst",
+    }
+)
+
 
 def observing_system_lid(instrument: str) -> str:
     return f"urn:nasa:pds:context:instrument:insthost.{instrument}"
@@ -85,4 +94,5 @@ def observing_system(instrument: str) -> NodeBuilder:
         "acs": acs_observing_system,
         "wfc3": wfc3_observing_system,
         "wfpc2": wfpc2_observing_system,
+        "nicmos": nicmos_observing_system,
     }[instrument]

--- a/pdart/pds4/HstFilename.py
+++ b/pdart/pds4/HstFilename.py
@@ -17,7 +17,7 @@ class HstFilename(object):
         ), "Filename must be at least six characters long"
         basename2 = basename(filename)
         assert (
-            basename2[0].lower() in "iju"
+            basename2[0].lower() in "ijnu"
         ), f"First char of filename {basename2!r} must be i, j, or u."
 
     def __str__(self) -> str:
@@ -36,11 +36,13 @@ class HstFilename(object):
         """
         filename = self._basename()
         i = filename[0].lower()
-        assert i in "iju", f"First char of filename {filename!r} must be i, j, or u."
+        assert i in "ijnu", f"First char of filename {filename!r} must be i, j, or u."
         if i == "i":
             return "wfc3"
         elif i == "j":
             return "acs"
+        elif i == "n":
+            return "nicmos"
         elif i == "u":
             return "wfpc2"
         else:

--- a/pdart/pipeline/BuildBrowse.py
+++ b/pdart/pipeline/BuildBrowse.py
@@ -5,7 +5,11 @@ from typing import List, Set
 import fs.path
 import picmaker
 
-from pdart.astroquery.Astroquery import ACCEPTED_SUFFIXES
+# from pdart.astroquery.Astroquery import ACCEPTED_SUFFIXES
+from pdart.astroquery.AcceptedSuffixes import (
+    ACCEPTED_SUFFIXES,
+    PART_OF_ACCEPTED_SUFFIXES,
+)
 from pdart.db.BundleDB import (
     BundleDB,
     _BUNDLE_DB_NAME,

--- a/pdart/pipeline/CheckDownloads.py
+++ b/pdart/pipeline/CheckDownloads.py
@@ -14,7 +14,6 @@ class CheckDownloads(MarkedStage):
         working_dir: str,
         mast_downloads_dir: str,
         proposal_id: int,
-        selected_suffixes: Optional[bool] = False,
     ) -> None:
         # first pass, <working_dir> shouldn't exist; second pass
         # <working_dir>/mastDownload should not exist.
@@ -25,7 +24,8 @@ class CheckDownloads(MarkedStage):
         slice = MastSlice((1900, 1, 1), (2025, 1, 1), proposal_id)
         proposal_ids = slice.get_proposal_ids()
         assert proposal_id in proposal_ids, f"{proposal_id} in {proposal_ids}"
-        product_set = slice.to_product_set(proposal_id, selected_suffixes)
+        # get files from full list of ACCEPTED_SUFFIXES
+        product_set = slice.to_product_set(proposal_id)
         if not os.path.isdir(working_dir):
             os.makedirs(working_dir)
 
@@ -45,5 +45,4 @@ class CheckDownloads(MarkedStage):
                 working_dir,
                 mast_downloads_dir,
                 self._proposal_id,
-                self._selected_suffixes,
             )

--- a/pdart/pipeline/CheckDownloads.py
+++ b/pdart/pipeline/CheckDownloads.py
@@ -1,5 +1,6 @@
 import os
 import os.path
+from typing import Optional
 
 from astropy.table.row import Row
 
@@ -9,7 +10,11 @@ from pdart.pipeline.Stage import MarkedStage
 
 class CheckDownloads(MarkedStage):
     def _do_downloads(
-        self, working_dir: str, mast_downloads_dir: str, proposal_id: int
+        self,
+        working_dir: str,
+        mast_downloads_dir: str,
+        proposal_id: int,
+        selected_suffixes: Optional[bool] = False,
     ) -> None:
         # first pass, <working_dir> shouldn't exist; second pass
         # <working_dir>/mastDownload should not exist.
@@ -20,7 +25,7 @@ class CheckDownloads(MarkedStage):
         slice = MastSlice((1900, 1, 1), (2025, 1, 1), proposal_id)
         proposal_ids = slice.get_proposal_ids()
         assert proposal_id in proposal_ids, f"{proposal_id} in {proposal_ids}"
-        product_set = slice.to_product_set(proposal_id)
+        product_set = slice.to_product_set(proposal_id, selected_suffixes)
         if not os.path.isdir(working_dir):
             os.makedirs(working_dir)
 
@@ -36,4 +41,9 @@ class CheckDownloads(MarkedStage):
         mast_downloads_dir: str = self.mast_downloads_dir()
 
         if not os.path.isdir(mast_downloads_dir):
-            self._do_downloads(working_dir, mast_downloads_dir, self._proposal_id)
+            self._do_downloads(
+                working_dir,
+                mast_downloads_dir,
+                self._proposal_id,
+                self._selected_suffixes,
+            )

--- a/pdart/pipeline/Directories.py
+++ b/pdart/pipeline/Directories.py
@@ -18,14 +18,8 @@ def make_directories() -> "Directories":
             ["/Volumes/AKBAR/working-dir", "/Volumes/PDART-8TB/working-dir"]
         )
     else:
-        # For now, working path is pointing to external drive, but leave the
-        # condition here for now in case we want to separate the working path
-        # for lil pipeline and pipline
-        if "LIL" in os.environ:
-            # Use this machine; for little tests
-            return DevDirectories(TWD)
-        else:
-            return DevDirectories(TWD)
+        # Working path, it is pointing to external drive now
+        return DevDirectories(TWD)
 
 
 class Directories(object, metaclass=abc.ABCMeta):

--- a/pdart/pipeline/Directories.py
+++ b/pdart/pipeline/Directories.py
@@ -18,13 +18,14 @@ def make_directories() -> "Directories":
             ["/Volumes/AKBAR/working-dir", "/Volumes/PDART-8TB/working-dir"]
         )
     else:
+        # For now, working path is pointing to external drive, but leave the
+        # condition here for now in case we want to separate the working path
+        # for lil pipeline and pipline
         if "LIL" in os.environ:
             # Use this machine; for little tests
             return DevDirectories(TWD)
-            # return DevDirectories("tmp-working-dir")
         else:
             return DevDirectories(TWD)
-            # return DevDirectories("/Volumes/Eric's-5TB/tmp-working-dir")
 
 
 class Directories(object, metaclass=abc.ABCMeta):

--- a/pdart/pipeline/Directories.py
+++ b/pdart/pipeline/Directories.py
@@ -1,6 +1,9 @@
 from typing import List
 import abc
+import os
 import os.path
+
+TWD = os.environ["TMP_WORKING_DIR"]
 
 # TODO Make this abstract and implement for development and also for
 # big-data.
@@ -17,9 +20,11 @@ def make_directories() -> "Directories":
     else:
         if "LIL" in os.environ:
             # Use this machine; for little tests
-            return DevDirectories("tmp-working-dir")
+            return DevDirectories(TWD)
+            # return DevDirectories("tmp-working-dir")
         else:
-            return DevDirectories("/Volumes/Eric's-5TB/tmp-working-dir")
+            return DevDirectories(TWD)
+            # return DevDirectories("/Volumes/Eric's-5TB/tmp-working-dir")
 
 
 class Directories(object, metaclass=abc.ABCMeta):

--- a/pdart/pipeline/Stage.py
+++ b/pdart/pipeline/Stage.py
@@ -13,12 +13,10 @@ class Stage(metaclass=abc.ABCMeta):
         self,
         dirs: Directories,
         proposal_id: int,
-        selected_suffixes: Optional[bool] = False,
     ) -> None:
         self._bundle_segment = f"hst_{proposal_id:05}"
         self._dirs = dirs
         self._proposal_id = proposal_id
-        self._selected_suffixes = selected_suffixes
 
     ##############################
 
@@ -87,9 +85,8 @@ class MarkedStage(Stage):
         self,
         dirs: Directories,
         proposal_id: int,
-        selected_suffixes: Optional[bool] = False,
     ) -> None:
-        Stage.__init__(self, dirs, proposal_id, selected_suffixes)
+        Stage.__init__(self, dirs, proposal_id)
         if not os.path.exists(self.working_dir()):
             os.makedirs(self.working_dir())
         self._marker_file = BasicMarkerFile(self.working_dir())

--- a/pdart/pipeline/Stage.py
+++ b/pdart/pipeline/Stage.py
@@ -2,16 +2,23 @@ import abc
 import os
 import os.path
 import traceback
+from typing import Optional
 
 from pdart.pipeline.Directories import Directories
 from pdart.pipeline.MarkerFile import BasicMarkerFile
 
 
 class Stage(metaclass=abc.ABCMeta):
-    def __init__(self, dirs: Directories, proposal_id: int) -> None:
+    def __init__(
+        self,
+        dirs: Directories,
+        proposal_id: int,
+        selected_suffixes: Optional[bool] = False,
+    ) -> None:
         self._bundle_segment = f"hst_{proposal_id:05}"
         self._dirs = dirs
         self._proposal_id = proposal_id
+        self._selected_suffixes = selected_suffixes
 
     ##############################
 
@@ -76,8 +83,13 @@ class Stage(metaclass=abc.ABCMeta):
 
 
 class MarkedStage(Stage):
-    def __init__(self, dirs: Directories, proposal_id: int) -> None:
-        Stage.__init__(self, dirs, proposal_id)
+    def __init__(
+        self,
+        dirs: Directories,
+        proposal_id: int,
+        selected_suffixes: Optional[bool] = False,
+    ) -> None:
+        Stage.__init__(self, dirs, proposal_id, selected_suffixes)
         if not os.path.exists(self.working_dir()):
             os.makedirs(self.working_dir())
         self._marker_file = BasicMarkerFile(self.working_dir())

--- a/pdart/pipeline/Stage.py
+++ b/pdart/pipeline/Stage.py
@@ -9,22 +9,23 @@ from pdart.pipeline.MarkerFile import BasicMarkerFile
 
 
 class Stage(metaclass=abc.ABCMeta):
+    """
+    Abstract class representing a stage of processing in the pipeline.
+    The stage is intended to run as a transaction: that is, if it
+    fails while running, it should roll back the state of the
+    directory to what it looked like when the stage started.  This
+    keeps garbage from one failed attempt from affecting future
+    attempts.
+
+    The class also accepts a list of directory paths that the stages
+    will use and provides them to the operation of the stage.
+    """
+
     def __init__(
         self,
         dirs: Directories,
         proposal_id: int,
     ) -> None:
-        """
-        Abstract class representing a stage of processing in the pipeline.
-        The stage is intended to run as a transaction: that is, if it
-        fails while running, it should roll back the state of the
-        directory to what it looked like when the stage started.  This
-        keeps garbage from one failed attempt from affecting future
-        attempts.
-
-        The class also accepts a list of directory paths that the stages
-        will use and provides them to the operation of the stage.
-        """
         self._bundle_segment = f"hst_{proposal_id:05}"
         self._dirs = dirs
         self._proposal_id = proposal_id
@@ -92,15 +93,16 @@ class Stage(metaclass=abc.ABCMeta):
 
 
 class MarkedStage(Stage):
+    """
+    A MarkedStage is a Stage that runs with a BasicMarkerFile to show
+    its progress.
+    """
+
     def __init__(
         self,
         dirs: Directories,
         proposal_id: int,
     ) -> None:
-        """
-        A MarkedStage is a Stage that runs with a BasicMarkerFile to show
-        its progress.
-        """
         Stage.__init__(self, dirs, proposal_id)
         if not os.path.exists(self.working_dir()):
             os.makedirs(self.working_dir())

--- a/pdart/pipeline/Stage.py
+++ b/pdart/pipeline/Stage.py
@@ -14,6 +14,17 @@ class Stage(metaclass=abc.ABCMeta):
         dirs: Directories,
         proposal_id: int,
     ) -> None:
+        """
+        Abstract class representing a stage of processing in the pipeline.
+        The stage is intended to run as a transaction: that is, if it
+        fails while running, it should roll back the state of the
+        directory to what it looked like when the stage started.  This
+        keeps garbage from one failed attempt from affecting future
+        attempts.
+
+        The class also accepts a list of directory paths that the stages
+        will use and provides them to the operation of the stage.
+        """
         self._bundle_segment = f"hst_{proposal_id:05}"
         self._dirs = dirs
         self._proposal_id = proposal_id
@@ -86,6 +97,10 @@ class MarkedStage(Stage):
         dirs: Directories,
         proposal_id: int,
     ) -> None:
+        """
+        A MarkedStage is a Stage that runs with a BasicMarkerFile to show
+        its progress.
+        """
         Stage.__init__(self, dirs, proposal_id)
         if not os.path.exists(self.working_dir()):
             os.makedirs(self.working_dir())

--- a/pdart/pipeline/StateMachine.py
+++ b/pdart/pipeline/StateMachine.py
@@ -24,13 +24,12 @@ class StateMachine(object):
         self,
         dirs: Directories,
         proposal_id: int,
-        selected_suffixes: Optional[bool] = False,
     ) -> None:
         self.marker_file = BasicMarkerFile(dirs.working_dir(proposal_id))
         self.stages = [
             ("RESETPIPELINE", ResetPipeline(dirs, proposal_id)),
             ("DOWNLOADDOCS", DownloadDocs(dirs, proposal_id)),
-            ("CHECKDOWNLOADS", CheckDownloads(dirs, proposal_id, selected_suffixes)),
+            ("CHECKDOWNLOADS", CheckDownloads(dirs, proposal_id)),
             ("COPYPRIMARYFILES", CopyPrimaryFiles(dirs, proposal_id)),
             ("RECORDCHANGES", RecordChanges(dirs, proposal_id)),
             ("INSERTCHANGES", InsertChanges(dirs, proposal_id)),

--- a/pdart/pipeline/StateMachine.py
+++ b/pdart/pipeline/StateMachine.py
@@ -20,16 +20,17 @@ from pdart.pipeline.ValidateBundle import ValidateBundle
 
 
 class StateMachine(object):
+    """
+    This object runs a list of pipeline stages, hardcoded into
+    self.stages.  It uses a BasicMarkerFile to show progress and
+    record the final state.
+    """
+
     def __init__(
         self,
         dirs: Directories,
         proposal_id: int,
     ) -> None:
-        """
-        This object runs a list of pipeline stages, hardcoded into
-        self.stages.  It uses a BasicMarkerFile to show progress and
-        record the final state.
-        """
         self.marker_file = BasicMarkerFile(dirs.working_dir(proposal_id))
         self.stages = [
             ("RESETPIPELINE", ResetPipeline(dirs, proposal_id)),

--- a/pdart/pipeline/StateMachine.py
+++ b/pdart/pipeline/StateMachine.py
@@ -25,6 +25,11 @@ class StateMachine(object):
         dirs: Directories,
         proposal_id: int,
     ) -> None:
+        """
+        This object runs a list of pipeline stages, hardcoded into
+        self.stages.  It uses a BasicMarkerFile to show progress and
+        record the final state.
+        """
         self.marker_file = BasicMarkerFile(dirs.working_dir(proposal_id))
         self.stages = [
             ("RESETPIPELINE", ResetPipeline(dirs, proposal_id)),

--- a/pdart/pipeline/StateMachine.py
+++ b/pdart/pipeline/StateMachine.py
@@ -20,12 +20,17 @@ from pdart.pipeline.ValidateBundle import ValidateBundle
 
 
 class StateMachine(object):
-    def __init__(self, dirs: Directories, proposal_id: int) -> None:
+    def __init__(
+        self,
+        dirs: Directories,
+        proposal_id: int,
+        selected_suffixes: Optional[bool] = False,
+    ) -> None:
         self.marker_file = BasicMarkerFile(dirs.working_dir(proposal_id))
         self.stages = [
             ("RESETPIPELINE", ResetPipeline(dirs, proposal_id)),
             ("DOWNLOADDOCS", DownloadDocs(dirs, proposal_id)),
-            ("CHECKDOWNLOADS", CheckDownloads(dirs, proposal_id)),
+            ("CHECKDOWNLOADS", CheckDownloads(dirs, proposal_id, selected_suffixes)),
             ("COPYPRIMARYFILES", CopyPrimaryFiles(dirs, proposal_id)),
             ("RECORDCHANGES", RecordChanges(dirs, proposal_id)),
             ("INSERTCHANGES", InsertChanges(dirs, proposal_id)),

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,5 @@ urllib3==1.25.8
 wcwidth==0.1.9
 webencodings==0.5.1
 zipp==3.1.0
+black==20.8b1
+julian==0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,4 +37,3 @@ wcwidth==0.1.9
 webencodings==0.5.1
 zipp==3.1.0
 black==20.8b1
-julian==0.14

--- a/validate-pdart
+++ b/validate-pdart
@@ -1,6 +1,6 @@
 #!/bin/bash
-
-BASE_DIR=${HOME}/pdart
+TOOLDIR=${HOME}/Desktop/seti/workspace
+BASE_DIR=${TOOLDIR}/pdart
 CONTEXT_PRODUCTS="${BASE_DIR}"/context-products.json
 XMLDIR=${BASE_DIR}/xml
 # Remove this scaffolding when switching to the new HST_Parameters implementation.


### PR DESCRIPTION
- Changes:
    - In make_fits_product_label, use get_exposure_duration to obtain the exposure duration value to store in start_stop_times.
    - Run pipeline for NICMOS by running make command:
        - ```make nicmos```
            - This will run the pipeline for proposal id: 07885
        - ```make lil-pipeline```
            - This will run the pipeline for proposal id: 07885 09059 09748 15505
    - Download .fits of shm & spt from mast by running make command:
        - ```make download-shm-spt```
            - This will download .fits of shm & spt for all proposal ids in PROJ_IDS from Makefile.
        - Note:
            - Now it will only download files from mast, but didn't run through pipeline and create xml. If we want to run through pipeline when only download shm & spt (without any raw files), we will have to ignore the missing info (no hdu_lookups) when creating xml label because lots of them are coming from rawish files (hdu_lookups). And at the end of the pipeline, it will fail the validation by validate tool due to missing info in xml. I have another branch that can do this. Let me know if this is what we want. 
    - Set the hardcoded path to environment variable:
        - PDSTOOLS_PATH is the path to pds-tools repo, for example: "/Users/yjchang/Desktop/seti/workspace/pds-tools"
        - TMP_WORKING_DIR is the path to temporary working directory for pdart, for example: "/Volumes/pdsdata/tmp-working-dir"