### PR TITLE
Get proposal id with moving target true

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ dmypy.json
 
 # Output from make
 tmp*.xml
+
+# Testing script
+TestMastResult.py

--- a/GetProposalIds.py
+++ b/GetProposalIds.py
@@ -1,0 +1,28 @@
+import os
+import sys
+from pdart.astroquery.AcceptedSuffixes import (
+    ACCEPTED_SUFFIXES,
+    PART_OF_ACCEPTED_SUFFIXES,
+)
+from pdart.astroquery.Astroquery import MastSlice, ProductSet
+from pdart.pipeline.Directories import DevDirectories
+
+# Download from Mast
+if __name__ == "__main__":
+    TWD = os.environ["TMP_WORKING_DIR"]
+    assert len(sys.argv) == 1, sys.argv
+    # Store the list of proposal ids as a text file in TWD
+    working_dir = TWD
+    if not os.path.isdir(working_dir):
+      os.makedirs(working_dir)
+    list_dir = f"{TWD}/proposal_ids.txt"
+    slice = MastSlice((1900, 1, 1), (2025, 1, 1))
+    proposal_ids_list = slice.get_proposal_ids()
+
+    # Write proposal ids into proposal_ids.txt
+    with open(list_dir, "w") as f:
+        count = 0
+        for proposal_id in proposal_ids_list:
+            f.write("%s\n" % proposal_id)
+            count +=1
+        f.write("Totol number of proposal ids: %s\n" % count)

--- a/GetProposalIds.py
+++ b/GetProposalIds.py
@@ -1,28 +1,71 @@
+from typing import Optional, Tuple
 import os
 import sys
 from pdart.astroquery.AcceptedSuffixes import (
     ACCEPTED_SUFFIXES,
     PART_OF_ACCEPTED_SUFFIXES,
 )
-from pdart.astroquery.Astroquery import MastSlice, ProductSet
+from pdart.astroquery.Astroquery import *
 from pdart.pipeline.Directories import DevDirectories
+
+_YMD = Tuple[int, int, int]
+
+# Customize MastSlice to use cutomized query criteria
+# Don't restrict product type to image
+class CustomizedQueryMastSlice(MastSlice):
+    def __init__(
+        self, start_date: _YMD, end_date: _YMD, proposal_id: Optional[int] = None
+    ) -> None:
+        super().__init__(start_date, end_date, proposal_id)
+
+        def mast_call() -> Table:
+            if proposal_id is not None:
+                return Observations.query_criteria(
+                    dataRights="PUBLIC",
+                    obs_collection=["HST"],
+                    proposal_id=str(proposal_id),
+                    t_obs_release=(self.start_date, self.end_date),
+                    mtFlag=True,
+                )
+            else:
+                return Observations.query_criteria(
+                    dataRights="PUBLIC",
+                    obs_collection=["HST"],
+                    t_obs_release=(self.start_date, self.end_date),
+                    mtFlag=True,
+                )
+
+        self.observations_table = get_table_with_retries(mast_call, 1)
+        self.proposal_ids: Optional[List[int]] = None
+
 
 # Download from Mast
 if __name__ == "__main__":
     TWD = os.environ["TMP_WORKING_DIR"]
-    assert len(sys.argv) == 1, sys.argv
+    assert len(sys.argv) == 2, sys.argv
     # Store the list of proposal ids as a text file in TWD
     working_dir = TWD
     if not os.path.isdir(working_dir):
-      os.makedirs(working_dir)
-    list_dir = f"{TWD}/proposal_ids.txt"
-    slice = MastSlice((1900, 1, 1), (2025, 1, 1))
-    proposal_ids_list = slice.get_proposal_ids()
+        os.makedirs(working_dir)
+
+    product_type = str(sys.argv[1])
+    if product_type == "all":
+        # Get the list of proposal ids with moving target = true
+        list_dir = f"{TWD}/proposal_ids_all.txt"
+        customized_query_slice = CustomizedQueryMastSlice((1900, 1, 1), (2025, 1, 1))
+        proposal_ids_list = customized_query_slice.get_proposal_ids()
+    elif product_type == "image":
+        # Get the list of proposal ids with image product type & moving target = true
+        list_dir = f"{TWD}/proposal_ids_image.txt"
+        slice = MastSlice((1900, 1, 1), (2025, 1, 1))
+        proposal_ids_list = slice.get_proposal_ids()
+    else:
+        assert False, "Invalid command for GetProposalIds.py"
 
     # Write proposal ids into proposal_ids.txt
     with open(list_dir, "w") as f:
         count = 0
         for proposal_id in proposal_ids_list:
             f.write("%s\n" % proposal_id)
-            count +=1
-        f.write("Totol number of proposal ids: %s\n" % count)
+            count += 1
+        f.write("Total number of proposal ids: %s\n" % count)

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,16 @@ download-shm-spt : setup_dir
 		python Download_SHM_SPT.py $$project_id; \
 	done;
 
+##############################
+# Get the list of proposal ids
+##############################
+.PHONY: get-proposal-ids
+get-proposal-ids : venv
+	mkdir -p $(LIL-TWD)
+	$(ACTIVATE) && PYTHONPATH=$(PDSTOOLS_PATH) \
+	python GetProposalIds.py; \
+	echo '**** List of Proposal Ids is created under' $(LIL-TWD) '****'; \
+
 ############################################################
 # Setup
 ############################################################

--- a/Makefile
+++ b/Makefile
@@ -160,14 +160,24 @@ download-shm-spt : setup_dir
 		python Download_SHM_SPT.py $$project_id; \
 	done;
 
-##############################
-# Get the list of proposal ids
-##############################
+############################################################
+# Get the list of proposal ids with moving target = true
+############################################################
 .PHONY: get-proposal-ids
 get-proposal-ids : venv
 	mkdir -p $(LIL-TWD)
 	$(ACTIVATE) && PYTHONPATH=$(PDSTOOLS_PATH) \
-	python GetProposalIds.py; \
+	python GetProposalIds.py all; \
+	echo '**** List of Proposal Ids is created under' $(LIL-TWD) '****'; \
+
+############################################################
+# Get the list of proposal ids with image product type & moving target = true
+############################################################
+.PHONY: get-image-proposal-ids
+get-image-proposal-ids : venv
+	mkdir -p $(LIL-TWD)
+	$(ACTIVATE) && PYTHONPATH=$(PDSTOOLS_PATH) \
+	python GetProposalIds.py image; \
 	echo '**** List of Proposal Ids is created under' $(LIL-TWD) '****'; \
 
 ############################################################


### PR DESCRIPTION
- Add following make targets: 
    - Get proposal ids with image product type & moving target = true: 
        - Command: ```make get-image-proposal-ids```
        - Log file name: ```proposal_ids_image.txt``` under your temp working directory
    - Get proposal ids with moving target = true: 
        - Command: ```make get-proposal-ids```
        - Log file name: ```proposal_ids_all.txt``` under your temp working directory